### PR TITLE
feat(ui): flash-era sitetshell and CSS-only pixel controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@
 # production
 /build
 
+# claude
+.claude/
+CLAUDE.md
+
 # misc
 .DS_Store
 *.pem

--- a/app/components/game/DecorativeFrame.tsx
+++ b/app/components/game/DecorativeFrame.tsx
@@ -1,107 +1,25 @@
 'use client';
 
-const TILE_SIZE = 128;
-const FRAME_BASE_PATH = '/assets/ui/game_frame';
-
-// Individual tile images
-const TILES = {
-  topLeft: `${FRAME_BASE_PATH}/top_left.png`,
-  topRight: `${FRAME_BASE_PATH}/top_right.png`,
-  bottomLeft: `${FRAME_BASE_PATH}/bottom_left.png`,
-  bottomRight: `${FRAME_BASE_PATH}/bottom_right.png`,
-  topSide: `${FRAME_BASE_PATH}/top_side.png`,
-  bottomSide: `${FRAME_BASE_PATH}/bottom_side.png`,
-  leftSide: `${FRAME_BASE_PATH}/left_side.png`,
-  rightSide: `${FRAME_BASE_PATH}/right_side.png`,
-};
-
 export function DecorativeFrame() {
-  const baseStyle = {
-    imageRendering: 'pixelated' as const,
-    backgroundSize: '128px 128px',
-  };
-
   return (
-    <div className="absolute -inset-6 pointer-events-none z-10">
-      {/* Top-left corner */}
-      <div
-        className="absolute top-0 left-0 w-32 h-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.topLeft})`,
-          backgroundRepeat: 'no-repeat',
-        }}
-      />
-
-      {/* Top-right corner */}
-      <div
-        className="absolute top-0 right-0 w-32 h-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.topRight})`,
-          backgroundRepeat: 'no-repeat',
-        }}
-      />
-
-      {/* Bottom-left corner */}
-      <div
-        className="absolute bottom-0 left-0 w-32 h-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.bottomLeft})`,
-          backgroundRepeat: 'no-repeat',
-        }}
-      />
-
-      {/* Bottom-right corner */}
-      <div
-        className="absolute bottom-0 right-0 w-32 h-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.bottomRight})`,
-          backgroundRepeat: 'no-repeat',
-        }}
-      />
-
-      {/* Top side - repeating between corners */}
-      <div
-        className="absolute top-0 left-32 right-32 h-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.topSide})`,
-          backgroundRepeat: 'repeat-x',
-        }}
-      />
-
-      {/* Bottom side - repeating between corners */}
-      <div
-        className="absolute bottom-0 left-32 right-32 h-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.bottomSide})`,
-          backgroundRepeat: 'repeat-x',
-        }}
-      />
-
-      {/* Left side - repeating between corners */}
-      <div
-        className="absolute left-0 top-32 bottom-32 w-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.leftSide})`,
-          backgroundRepeat: 'repeat-y',
-        }}
-      />
-
-      {/* Right side - repeating between corners */}
-      <div
-        className="absolute right-0 top-32 bottom-32 w-32"
-        style={{
-          ...baseStyle,
-          backgroundImage: `url(${TILES.rightSide})`,
-          backgroundRepeat: 'repeat-y',
-        }}
-      />
-    </div>
+    <div
+      className="absolute -inset-6 pointer-events-none z-10"
+      style={{
+        borderWidth: '24px',
+        borderStyle: 'solid',
+        borderTopColor: '#c49050',
+        borderLeftColor: '#c49050',
+        borderRightColor: '#2a1808',
+        borderBottomColor: '#2a1808',
+        boxShadow: [
+          '0 0 0 3px #1a0c06',
+          '0 0 0 6px #7a4c24',
+          '0 0 0 9px #1a0c06',
+          '10px 10px 0 rgba(0,0,0,0.45)',
+          'inset 0 0 0 4px rgba(0,0,0,0.3)',
+        ].join(', '),
+        imageRendering: 'pixelated' as const,
+      }}
+    />
   );
 }

--- a/app/components/game/DesktopGameFrame.tsx
+++ b/app/components/game/DesktopGameFrame.tsx
@@ -44,7 +44,7 @@ export function DesktopGameFrame({
   }, [gameEngine]);
 
   return (
-    <div className="w-full flex items-center justify-center py-8" style={{ backgroundColor: '#eeeeee' }}>
+    <div className="w-full flex items-center justify-center py-8" style={{ backgroundColor: '#1a1a1a' }}>
       {/* Game frame container - height-based sizing with aspect ratio */}
       <div className="relative p-6" style={{ height: '70vh', aspectRatio: '16/9' }}>
         <div className="relative w-full h-full">

--- a/app/components/game/GameDetails.tsx
+++ b/app/components/game/GameDetails.tsx
@@ -1,174 +1,126 @@
 "use client";
 
+const TECH_STACK = [
+  { name: 'Next.js 16', color: '#0070f3' },
+  { name: 'React 19', color: '#61dafb' },
+  { name: 'TypeScript', color: '#3178c6' },
+  { name: 'HTML5 Canvas', color: '#e34c26' },
+  { name: 'Tailwind CSS', color: '#38bdf8' },
+];
+
 export function GameDetails() {
   return (
-    <div
-      className="w-full py-4 px-4"
-      style={{ maxWidth: "calc(70vh * 16 / 9)" }}
-    >
-      <div className="w-full">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {/* Left Column: Instructions & Controls */}
-          <div className="space-y-6">
-            {/* Game Instructions */}
-            <section className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                How to Play
-              </h2>
-              <ul className="space-y-2 text-gray-700">
-                <li className="flex items-start">
-                  <span className="text-blue-500 mr-2">•</span>
-                  <span>Ride your bike through an endless scrolling world</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-blue-500 mr-2">•</span>
-                  <span>Collect pizzas to earn points</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-blue-500 mr-2">•</span>
-                  <span>Jump over monsters to avoid getting hit</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-blue-500 mr-2">•</span>
-                  <span>
-                    Low pizzas can only be collected while on the ground
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-blue-500 mr-2">•</span>
-                  <span>High pizzas require jumping to collect</span>
-                </li>
-              </ul>
-            </section>
-
-            {/* Points System */}
-            <section className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">Scoring</h2>
-              <div className="space-y-2 text-gray-700">
-                <div className="flex justify-between items-center">
-                  <span>🍕 Collect Pizza</span>
-                  <span className="font-bold text-green-600">+10 points</span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span>👾 Kill Monster (jump)</span>
-                  <span className="font-bold text-green-600">+50 points</span>
-                </div>
-              </div>
-            </section>
-
-            {/* Technologies */}
-            <section className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                Technologies Used
-              </h2>
-              <div className="grid grid-cols-2 gap-3 text-gray-700">
-                <div className="flex items-center">
-                  <span className="text-blue-500 mr-2">▸</span>
-                  <span>Next.js 16</span>
-                </div>
-                <div className="flex items-center">
-                  <span className="text-blue-500 mr-2">▸</span>
-                  <span>React 19</span>
-                </div>
-                <div className="flex items-center">
-                  <span className="text-blue-500 mr-2">▸</span>
-                  <span>TypeScript</span>
-                </div>
-                <div className="flex items-center">
-                  <span className="text-blue-500 mr-2">▸</span>
-                  <span>HTML5 Canvas</span>
-                </div>
-                <div className="flex items-center">
-                  <span className="text-blue-500 mr-2">▸</span>
-                  <span>Tailwind CSS</span>
-                </div>
-              </div>
-            </section>
+    <div style={{ fontFamily: 'Verdana, Arial, sans-serif' }}>
+      {/* Row 1: How to Play + Controls */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+        <div className="flash-panel">
+          <div className="flash-panel-header">How to Play</div>
+          <div className="flash-panel-body">
+            <ul style={{ margin: 0, paddingLeft: '16px' }}>
+              <li style={{ marginBottom: '5px' }}>Ride your bike through an endless side-scrolling world</li>
+              <li style={{ marginBottom: '5px' }}>Collect pizzas floating in the air to earn points</li>
+              <li style={{ marginBottom: '5px' }}>Jump over monsters to avoid getting hit — or stomp them!</li>
+              <li style={{ marginBottom: '5px' }}>Low pizzas: collect while on the ground</li>
+              <li>High pizzas: jump to reach them</li>
+            </ul>
           </div>
+        </div>
 
-          {/* Right Column: Technologies & Credits */}
-          <div className="space-y-6">
-            {/* Controls */}
-            <section className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                Controls
-              </h2>
-              <div className="space-y-3 text-gray-700">
-                <div className="flex items-center">
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    A
-                  </kbd>
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    ←
-                  </kbd>
-                  <span>Move Left</span>
-                </div>
-                <div className="flex items-center">
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    D
-                  </kbd>
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    →
-                  </kbd>
-                  <span>Move Right</span>
-                </div>
-                <div className="flex items-center">
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    W
-                  </kbd>
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    ↑
-                  </kbd>
-                  <kbd className="px-3 py-1 bg-gray-200 rounded text-sm font-mono mr-3">
-                    Space
-                  </kbd>
-                  <span>Jump (Bunny Hop)</span>
-                </div>
-              </div>
-            </section>
+        <div className="flash-panel">
+          <div className="flash-panel-header">Controls</div>
+          <div className="flash-panel-body">
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <tbody>
+                <tr style={{ borderBottom: '1px solid #2a2a2a' }}>
+                  <td style={{ padding: '5px 0', width: '45%' }}>
+                    <span className="flash-kbd">A</span>&nbsp;/&nbsp;<span className="flash-kbd">&#8592;</span>
+                  </td>
+                  <td style={{ padding: '5px 0', color: '#ccc' }}>Move Left</td>
+                </tr>
+                <tr style={{ borderBottom: '1px solid #2a2a2a' }}>
+                  <td style={{ padding: '5px 0' }}>
+                    <span className="flash-kbd">D</span>&nbsp;/&nbsp;<span className="flash-kbd">&#8594;</span>
+                  </td>
+                  <td style={{ padding: '5px 0', color: '#ccc' }}>Move Right</td>
+                </tr>
+                <tr>
+                  <td style={{ padding: '5px 0' }}>
+                    <span className="flash-kbd">W</span>&nbsp;/&nbsp;<span className="flash-kbd">&#8593;</span>&nbsp;/&nbsp;<span className="flash-kbd">Space</span>
+                  </td>
+                  <td style={{ padding: '5px 0', color: '#ccc' }}>Bunny Hop</td>
+                </tr>
+              </tbody>
+            </table>
+            <div style={{ marginTop: '10px', padding: '6px 8px', background: '#161616', border: '1px solid #2a2a2a', color: '#666', fontSize: '10px' }}>
+              Mobile: use the on-screen D-pad controls
+            </div>
+          </div>
+        </div>
+      </div>
 
-            {/* Credits */}
-            <section className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">Credits</h2>
-              <div className="space-y-4 text-gray-700">
-                <div>
-                  <h3 className="font-semibold text-gray-800 mb-2">Music</h3>
-                  <p className="text-sm">
-                    "Cloud Dancer" by{" "}
-                    <a
-                      href="https://incompetech.com/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:text-blue-800 underline"
-                    >
-                      Kevin MacLeod
-                    </a>
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    Licensed under{" "}
-                    <a
-                      href="https://creativecommons.org/licenses/by/4.0/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:text-blue-800 underline"
-                    >
-                      Creative Commons: By Attribution 4.0
-                    </a>
-                  </p>
-                  <p className="text-xs text-gray-500">
-                    Source:{" "}
-                    <a
-                      href="https://incompetech.com/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:text-blue-800 underline"
-                    >
-                      incompetech.com
-                    </a>
-                  </p>
-                </div>
+      {/* Row 2: Scoring + Technology + Credits */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <div className="flash-panel">
+          <div className="flash-panel-header">Scoring</div>
+          <div className="flash-panel-body">
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <tbody>
+                <tr style={{ borderBottom: '1px solid #2a2a2a' }}>
+                  <td style={{ padding: '6px 0' }}>🍕 Collect Pizza</td>
+                  <td style={{ padding: '6px 0', textAlign: 'right', color: '#44cc66', fontWeight: 'bold' }}>+10 pts</td>
+                </tr>
+                <tr>
+                  <td style={{ padding: '6px 0' }}>👾 Kill Monster</td>
+                  <td style={{ padding: '6px 0', textAlign: 'right', color: '#44cc66', fontWeight: 'bold' }}>+50 pts</td>
+                </tr>
+              </tbody>
+            </table>
+            <div style={{ marginTop: '8px', fontSize: '10px', color: '#555', borderTop: '1px solid #2a2a2a', paddingTop: '8px' }}>
+              Tip: stomp monsters by landing on top
+            </div>
+          </div>
+        </div>
+
+        <div className="flash-panel">
+          <div className="flash-panel-header">Technology</div>
+          <div className="flash-panel-body">
+            {TECH_STACK.map(({ name, color }) => (
+              <div key={name} style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
+                <div style={{ width: '6px', height: '6px', background: color, flexShrink: 0 }} />
+                <span style={{ color: '#ccc' }}>{name}</span>
               </div>
-            </section>
+            ))}
+          </div>
+        </div>
+
+        <div className="flash-panel">
+          <div className="flash-panel-header">Credits</div>
+          <div className="flash-panel-body">
+            <div style={{ marginBottom: '10px' }}>
+              <div style={{ color: '#ff9900', fontWeight: 'bold', marginBottom: '4px', fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                Music
+              </div>
+              <div style={{ color: '#ccc' }}>&ldquo;Cloud Dancer&rdquo;</div>
+              <div>
+                by{' '}
+                <a href="https://incompetech.com/" target="_blank" rel="noopener noreferrer" className="flash-link">
+                  Kevin MacLeod
+                </a>
+              </div>
+              <div style={{ fontSize: '10px', color: '#555', marginTop: '4px' }}>
+                Licensed under{' '}
+                <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer" className="flash-link" style={{ color: '#555' }}>
+                  CC BY 4.0
+                </a>
+              </div>
+            </div>
+            <div style={{ borderTop: '1px solid #2a2a2a', paddingTop: '8px' }}>
+              <div style={{ color: '#ff9900', fontWeight: 'bold', marginBottom: '4px', fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                Developer
+              </div>
+              <a href="#" className="flash-username">hmcldryl</a>
+              <div style={{ fontSize: '10px', color: '#555', marginTop: '2px' }}>Palawan, Philippines</div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/components/game/MobileGameFrame.tsx
+++ b/app/components/game/MobileGameFrame.tsx
@@ -85,7 +85,7 @@ function MobilePortraitLayout({
   }, [gameEngine]);
 
   return (
-    <div className="w-full h-screen flex flex-col" style={{ backgroundColor: '#eeeeee' }}>
+    <div className="w-full h-screen flex flex-col" style={{ backgroundColor: '#1a1a1a' }}>
       {/* Game area - takes available space minus controls */}
       <div className="flex-1 flex items-center justify-center p-4">
         <div className="relative w-full max-w-full" style={{ aspectRatio: '16/9' }}>
@@ -154,7 +154,7 @@ function MobileLandscapeLayout({
   }, [gameEngine]);
 
   return (
-    <div className="w-full h-screen flex items-center justify-center" style={{ backgroundColor: '#eeeeee' }}>
+    <div className="w-full h-screen flex items-center justify-center" style={{ backgroundColor: '#1a1a1a' }}>
       {/* Minimal padding for frame, max screen usage */}
       <div className="relative h-full p-2" style={{ aspectRatio: '16/9' }}>
         <div className="relative w-full h-full">

--- a/app/components/game/TitleScreen.tsx
+++ b/app/components/game/TitleScreen.tsx
@@ -9,23 +9,22 @@ interface TitleScreenProps {
 export function TitleScreen({ onPlay }: TitleScreenProps) {
   return (
     <div className="absolute inset-0 z-30 flex flex-col items-center justify-center bg-black/50 pointer-events-none">
-      {/* Title text */}
       <h1 className="text-4xl md:text-6xl font-pixel text-white mb-16 drop-shadow-lg text-center px-4">
-        Dada's Ride Out
+        Dada&apos;s Ride Out
       </h1>
 
-      {/* Play button using sprite - 3x larger */}
       <div className="mb-8 pointer-events-auto">
         <SpriteButton
-          spriteBasePath="/assets/ui/controls/play"
           onClick={onPlay}
           ariaLabel="Start game"
           width={288}
-          height={144}
-        />
+          height={96}
+          variant="play"
+        >
+          ▶ PLAY
+        </SpriteButton>
       </div>
 
-      {/* Subtitle */}
       <p className="text-sm md:text-base text-white/80 text-center px-4">
         Press Play to Start
       </p>

--- a/app/components/game/controls/DirectionalControls.tsx
+++ b/app/components/game/controls/DirectionalControls.tsx
@@ -34,16 +34,16 @@ export function DirectionalControls() {
   return (
     <div className="flex gap-4 items-end">
       <SpriteButton
-        spriteBasePath="/assets/ui/controls/arrow_left"
         onMouseDown={handleLeftDown}
         onMouseUp={handleLeftUp}
         onTouchStart={handleLeftDown}
         onTouchEnd={handleLeftUp}
         ariaLabel="Move left"
         size={64}
-      />
+      >
+        ◄
+      </SpriteButton>
       <SpriteButton
-        spriteBasePath="/assets/ui/controls/jump"
         onMouseDown={handleJumpDown}
         onMouseUp={handleJumpUp}
         onTouchStart={handleJumpDown}
@@ -51,16 +51,19 @@ export function DirectionalControls() {
         ariaLabel="Jump"
         width={128}
         height={64}
-      />
+      >
+        ▲
+      </SpriteButton>
       <SpriteButton
-        spriteBasePath="/assets/ui/controls/arrow_right"
         onMouseDown={handleRightDown}
         onMouseUp={handleRightUp}
         onTouchStart={handleRightDown}
         onTouchEnd={handleRightUp}
         ariaLabel="Move right"
         size={64}
-      />
+      >
+        ►
+      </SpriteButton>
     </div>
   );
 }

--- a/app/components/ui/SpriteButton.tsx
+++ b/app/components/ui/SpriteButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 
 interface SpriteButtonProps {
-  spriteBasePath: string;
+  children: React.ReactNode;
   onClick?: () => void;
   onMouseDown?: () => void;
   onMouseUp?: () => void;
@@ -13,10 +13,11 @@ interface SpriteButtonProps {
   size?: number;
   width?: number;
   height?: number;
+  variant?: 'default' | 'play';
 }
 
 export function SpriteButton({
-  spriteBasePath,
+  children,
   onClick,
   onMouseDown,
   onMouseUp,
@@ -26,71 +27,61 @@ export function SpriteButton({
   size = 64,
   width,
   height,
+  variant = 'default',
 }: SpriteButtonProps) {
-  const [buttonState, setButtonState] = useState<'normal' | 'hover' | 'pressed'>('normal');
+  const [isPressed, setIsPressed] = useState(false);
 
-  // Use width/height if provided, otherwise use size for both
   const buttonWidth = width ?? size;
   const buttonHeight = height ?? size;
 
-  const handleMouseEnter = () => {
-    if (buttonState !== 'pressed') {
-      setButtonState('hover');
-    }
-  };
-
-  const handleMouseLeave = () => {
-    setButtonState('normal');
-  };
-
   const handleMouseDown = () => {
-    setButtonState('pressed');
+    setIsPressed(true);
     onMouseDown?.();
   };
 
   const handleMouseUp = () => {
-    setButtonState('hover');
+    setIsPressed(false);
     onMouseUp?.();
+  };
+
+  const handleMouseLeave = () => {
+    if (isPressed) {
+      setIsPressed(false);
+      onMouseUp?.();
+    }
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {
     e.preventDefault();
-    setButtonState('pressed');
+    setIsPressed(true);
     onTouchStart?.();
   };
 
   const handleTouchEnd = (e: React.TouchEvent) => {
     e.preventDefault();
-    setButtonState('normal');
+    setIsPressed(false);
     onTouchEnd?.();
   };
 
-  const handleClick = () => {
-    console.log('SpriteButton clicked, onClick:', onClick);
-    onClick?.();
-  };
+  const classNames = [
+    'pixel-ctrl-btn',
+    variant === 'play' ? 'pixel-ctrl-btn-play' : '',
+    isPressed ? 'is-pressed' : '',
+  ].filter(Boolean).join(' ');
 
   return (
     <button
-      className="relative cursor-pointer border-none bg-transparent p-0 m-0 pointer-events-auto"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      className={classNames}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
-      onClick={handleClick}
+      onClick={onClick}
       aria-label={ariaLabel}
-      style={{
-        width: `${buttonWidth}px`,
-        height: `${buttonHeight}px`,
-        backgroundImage: `url(${spriteBasePath}_${buttonState}.png)`,
-        backgroundSize: 'contain',
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: 'center',
-        imageRendering: 'pixelated',
-        outline: 'none',
-      }}
-    />
+      style={{ width: `${buttonWidth}px`, height: `${buttonHeight}px` }}
+    >
+      {children}
+    </button>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,28 +3,20 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #2d2d2d;
+  --foreground: #cccccc;
 }
 
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: Verdana, Arial, Helvetica, sans-serif;
   margin: 0;
   padding: 0;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
-/* Pixel art rendering - disable antialiasing for crisp pixels */
 canvas {
   image-rendering: pixelated;
   image-rendering: -moz-crisp-edges;
@@ -36,10 +28,9 @@ canvas {
 .game-canvas {
   display: block;
   margin: 0 auto;
-  background: #eeeeee;
+  background: #1a1a1a;
 }
 
-/* Pixel art font styling */
 .pixel-text {
   font-family: var(--font-press-start), 'Press Start 2P', monospace;
   -webkit-font-smoothing: none;
@@ -47,7 +38,6 @@ canvas {
   font-smooth: never;
 }
 
-/* Pixel art borders for UI elements */
 .pixel-border {
   border: 4px solid #3e2723;
   box-shadow:
@@ -56,7 +46,6 @@ canvas {
   image-rendering: pixelated;
 }
 
-/* Utility classes for game UI */
 .pixel-button {
   @apply pixel-border pixel-text;
   background: #f5f5dc;
@@ -80,35 +69,45 @@ canvas {
     2px 2px 0 0 rgba(0, 0, 0, 0.3);
 }
 
-/* Icon button styles */
 .pixel-icon-button {
-  @apply pixel-border;
-  width: 48px;
-  height: 48px;
-  background: #f5f5dc;
-  cursor: pointer;
-  transition: transform 0.1s;
-  user-select: none;
-  display: flex;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: none;
+  border: none;
+  outline: none;
+  image-rendering: pixelated;
+  background: #c4a870;
+  color: #2a1a0a;
+  font-size: 18px;
+  box-shadow:
+    0 0 0 4px #2a1a0a,
+    inset 3px 3px 0 0 #e8d4a0,
+    inset -3px -3px 0 0 #6a4c28,
+    3px 3px 0 0 rgba(0, 0, 0, 0.5);
 }
-
 .pixel-icon-button:hover {
-  transform: translate(-2px, -2px);
+  background: #d4b880;
   box-shadow:
-    0 0 0 2px #8b6f47 inset,
-    6px 6px 0 0 rgba(0, 0, 0, 0.3);
+    0 0 0 4px #2a1a0a,
+    inset 3px 3px 0 0 #f4e4b0,
+    inset -3px -3px 0 0 #7a5c38,
+    3px 3px 0 0 rgba(0, 0, 0, 0.5);
 }
-
 .pixel-icon-button:active {
-  transform: translate(2px, 2px);
+  background: #b49860;
   box-shadow:
-    0 0 0 2px #8b6f47 inset,
-    2px 2px 0 0 rgba(0, 0, 0, 0.3);
+    0 0 0 4px #2a1a0a,
+    inset 3px 3px 0 0 #6a4c28,
+    inset -3px -3px 0 0 #e8d4a0,
+    1px 1px 0 0 rgba(0, 0, 0, 0.5);
+  transform: translate(2px, 2px);
 }
 
-/* Virtual D-pad button styles */
 .virtual-control-button {
   @apply pixel-border;
   width: 64px;
@@ -126,4 +125,251 @@ canvas {
 .virtual-control-button:active {
   background: rgba(245, 245, 220, 1);
   transform: scale(0.95);
+}
+
+/* ===== 16-bit Pixel Control Buttons ===== */
+
+.pixel-ctrl-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  border: none;
+  outline: none;
+  font-family: var(--font-press-start), 'Press Start 2P', monospace;
+  font-size: 24px;
+  image-rendering: pixelated;
+  background: #c4a870;
+  color: #2a1a0a;
+  box-shadow:
+    0 0 0 4px #2a1a0a,
+    inset 4px 4px 0 0 #e8d4a0,
+    inset -4px -4px 0 0 #6a4c28,
+    4px 4px 0 0 rgba(0, 0, 0, 0.5);
+}
+.pixel-ctrl-btn:hover {
+  background: #d4b880;
+  box-shadow:
+    0 0 0 4px #2a1a0a,
+    inset 4px 4px 0 0 #f4e4b0,
+    inset -4px -4px 0 0 #7a5c38,
+    4px 4px 0 0 rgba(0, 0, 0, 0.5);
+}
+.pixel-ctrl-btn:active,
+.pixel-ctrl-btn.is-pressed {
+  background: #b49860;
+  box-shadow:
+    0 0 0 4px #2a1a0a,
+    inset 4px 4px 0 0 #6a4c28,
+    inset -4px -4px 0 0 #e8d4a0,
+    2px 2px 0 0 rgba(0, 0, 0, 0.5);
+  transform: translate(2px, 2px);
+}
+
+.pixel-ctrl-btn-play {
+  background: #3c9828;
+  color: #ffffff;
+  font-size: 16px;
+  letter-spacing: 2px;
+  box-shadow:
+    0 0 0 4px #0e2808,
+    inset 4px 4px 0 0 #70cc50,
+    inset -4px -4px 0 0 #1e5010,
+    6px 6px 0 0 rgba(0, 0, 0, 0.5);
+}
+.pixel-ctrl-btn-play:hover {
+  background: #4caa38;
+  box-shadow:
+    0 0 0 4px #0e2808,
+    inset 4px 4px 0 0 #84dc64,
+    inset -4px -4px 0 0 #2a6018,
+    6px 6px 0 0 rgba(0, 0, 0, 0.5);
+}
+.pixel-ctrl-btn-play:active,
+.pixel-ctrl-btn-play.is-pressed {
+  background: #2c7818;
+  box-shadow:
+    0 0 0 4px #0e2808,
+    inset 4px 4px 0 0 #1e5010,
+    inset -4px -4px 0 0 #70cc50,
+    2px 2px 0 0 rgba(0, 0, 0, 0.5);
+  transform: translate(4px, 4px);
+}
+
+/* ===== Flash Game Site Theme ===== */
+
+.flash-site {
+  background: #2d2d2d;
+  color: #cccccc;
+  font-family: Verdana, Arial, Helvetica, sans-serif;
+}
+
+.flash-nav-link {
+  color: #bbbbbb;
+  text-decoration: none;
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 4px 8px;
+  display: inline-block;
+  white-space: nowrap;
+  font-family: Verdana, Arial, sans-serif;
+}
+.flash-nav-link:hover { color: #ff9900; }
+
+.flash-cat-link {
+  color: #888888;
+  text-decoration: none;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-family: Verdana, Arial, sans-serif;
+}
+.flash-cat-link:hover { color: #ff9900; }
+
+.flash-btn-orange {
+  background: linear-gradient(to bottom, #f07010, #b83c00);
+  color: #ffffff;
+  border: 1px solid #903000;
+  border-bottom-width: 2px;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  padding: 4px 10px;
+  text-decoration: none;
+  display: inline-block;
+  white-space: nowrap;
+  font-family: Verdana, Arial, sans-serif;
+  line-height: 1.4;
+}
+.flash-btn-orange:hover { background: linear-gradient(to bottom, #ff8020, #cc4800); }
+.flash-btn-orange:active { background: linear-gradient(to bottom, #b83c00, #f07010); }
+
+.flash-btn-blue {
+  background: linear-gradient(to bottom, #3377cc, #1155aa);
+  color: #ffffff;
+  border: 1px solid #224488;
+  border-bottom-width: 2px;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  padding: 4px 10px;
+  text-decoration: none;
+  display: inline-block;
+  white-space: nowrap;
+  font-family: Verdana, Arial, sans-serif;
+  line-height: 1.4;
+}
+.flash-btn-blue:hover { background: linear-gradient(to bottom, #4488dd, #2266bb); }
+.flash-btn-blue:active { background: linear-gradient(to bottom, #1155aa, #3377cc); }
+
+.flash-panel {
+  border: 1px solid #444444;
+  overflow: hidden;
+}
+
+.flash-panel-header {
+  background: linear-gradient(to bottom, #383838, #282828);
+  border-bottom: 2px solid #e8660a;
+  color: #ff9900;
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 6px 10px;
+  font-family: Verdana, Arial, sans-serif;
+}
+
+.flash-panel-body {
+  background: #1e1e1e;
+  padding: 10px 12px;
+  font-size: 11px;
+  color: #bbbbbb;
+  line-height: 1.7;
+  font-family: Verdana, Arial, sans-serif;
+}
+
+.flash-tag {
+  display: inline-block;
+  background: #333333;
+  border: 1px solid #555555;
+  color: #999999;
+  font-size: 10px;
+  padding: 2px 7px;
+  cursor: pointer;
+  font-family: Verdana, Arial, sans-serif;
+  text-decoration: none;
+}
+.flash-tag:hover {
+  background: #3d3d3d;
+  color: #ff9900;
+  border-color: #e8660a;
+}
+
+.flash-kbd {
+  background: #3a3a3a;
+  border: 1px solid #666666;
+  border-bottom: 2px solid #888888;
+  color: #e0e0e0;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 10px;
+  padding: 2px 6px;
+  display: inline-block;
+}
+
+.flash-comment-item {
+  padding: 10px 12px;
+  border-bottom: 1px solid #2e2e2e;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  background: #1e1e1e;
+}
+.flash-comment-item:last-child { border-bottom: none; }
+
+.flash-username {
+  color: #e8660a;
+  font-weight: bold;
+  font-size: 11px;
+  text-decoration: none;
+  font-family: Verdana, Arial, sans-serif;
+}
+.flash-username:hover {
+  text-decoration: underline;
+  color: #ff9900;
+}
+
+.flash-link {
+  color: #e8660a;
+  text-decoration: none;
+}
+.flash-link:hover {
+  text-decoration: underline;
+  color: #ff9900;
+}
+
+.flash-input {
+  background: #1a1a1a;
+  border: 1px solid #555555;
+  border-bottom: 2px solid #333333;
+  color: #cccccc;
+  font-family: Verdana, Arial, sans-serif;
+  font-size: 11px;
+  padding: 4px 8px;
+  width: 100%;
+  outline: none;
+  box-sizing: border-box;
+}
+.flash-input:focus {
+  border-color: #e8660a;
+  border-bottom-color: #c04000;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,351 @@
 import { GameContainer } from "./components/game/GameContainer";
 import { GameDetails } from "./components/game/GameDetails";
 
+const SITE_CATEGORIES = ['Action', 'Adventure', 'Puzzle', 'Sports', 'Shooting', 'RPG', 'Strategy', 'Platformer', 'Other'];
+const NAV_LINKS = ['Games', 'Movies', 'Art', 'Music', 'Forum', 'Submit'];
+const GAME_TAGS = ['pixel-art', 'side-scroller', 'bike', 'action', 'palawan'];
+const FOOTER_LINKS = ['About', 'Contact', 'Privacy Policy', 'Terms of Use', 'Advertise', 'Jobs'];
+
+const FAKE_COMMENTS = [
+  {
+    id: 1,
+    username: 'xXBikeKing99Xx',
+    level: 12,
+    text: 'omg this game is so sick!!!! the pixel art looks amazing and the controls are super tight. 10/10 would recommend!! also palawan is the best place in the philippines',
+    stars: 5,
+    date: 'Jan 15, 2025',
+    avatarColor: '#3377cc',
+    avatarLetter: 'B',
+  },
+  {
+    id: 2,
+    username: 'PizzaCollector2000',
+    level: 7,
+    text: "been playing this for like 3 hours straight lmao cant stop collecting pizzas. one question - can you actually kill the monsters or just jump over them?? trying to figure out the scoring",
+    stars: 4,
+    date: 'Feb 3, 2025',
+    avatarColor: '#cc3333',
+    avatarLetter: 'P',
+  },
+  {
+    id: 3,
+    username: 'retrogamer_ph',
+    level: 23,
+    text: 'nice press start 2p font, brings back memories. gameplay is smooth and the parallax background looks real good. small nitpick: wish the jump was a bit more floaty but still a great game overall',
+    stars: 5,
+    date: 'Mar 10, 2025',
+    avatarColor: '#33aa55',
+    avatarLetter: 'R',
+  },
+  {
+    id: 4,
+    username: 'flashnostalgia',
+    level: 35,
+    text: "cant believe html5 games have gotten this good. this reminds me of the old newgrounds era except without the random violence lol. the bike physics feel smooth. also love that the world moves instead of the player",
+    stars: 4,
+    date: 'Apr 22, 2025',
+    avatarColor: '#aa6600',
+    avatarLetter: 'F',
+  },
+];
+
+function FlashHeader() {
+  return (
+    <header style={{ background: '#111111', borderBottom: '2px solid #e8660a' }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '8px 20px',
+        flexWrap: 'wrap',
+        gap: '8px',
+      }}>
+        {/* Logo */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <div style={{
+            background: 'linear-gradient(135deg, #e8660a 0%, #ff9900 100%)',
+            color: '#fff',
+            fontFamily: 'Impact, "Arial Narrow", Arial, sans-serif',
+            fontSize: '26px',
+            fontWeight: 'bold',
+            padding: '3px 12px 4px',
+            letterSpacing: '3px',
+            border: '1px solid rgba(255,153,0,0.4)',
+            textShadow: '1px 2px 0 rgba(0,0,0,0.6)',
+            lineHeight: '1',
+          }}>
+            DADA
+          </div>
+          <div style={{
+            color: '#777',
+            fontFamily: 'Verdana, Arial, sans-serif',
+            fontSize: '10px',
+            fontWeight: 'bold',
+            letterSpacing: '5px',
+            textTransform: 'uppercase',
+          }}>
+            ARCADE
+          </div>
+        </div>
+
+        {/* Nav + auth */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '2px', flexWrap: 'wrap' }}>
+          {NAV_LINKS.map((item) => (
+            <a key={item} href="#" className="flash-nav-link">{item}</a>
+          ))}
+          <span style={{ color: '#333', padding: '0 6px', fontFamily: 'Verdana, Arial, sans-serif' }}>|</span>
+          <a href="#" className="flash-btn-orange" style={{ padding: '3px 10px' }}>Login</a>
+          <a href="#" className="flash-btn-blue" style={{ padding: '3px 10px', marginLeft: '3px' }}>Register</a>
+        </div>
+      </div>
+
+      {/* Category bar */}
+      <div style={{ background: '#0d0d0d', borderTop: '1px solid #222', padding: '4px 20px' }}>
+        <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
+          {SITE_CATEGORIES.map((cat) => (
+            <a key={cat} href="#" className="flash-cat-link">{cat}</a>
+          ))}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function FlashFooter() {
+  return (
+    <footer style={{
+      background: '#0d0d0d',
+      borderTop: '2px solid #1e1e1e',
+      marginTop: '40px',
+      padding: '24px 20px',
+      fontFamily: 'Verdana, Arial, sans-serif',
+      fontSize: '10px',
+      color: '#444',
+      textAlign: 'center',
+    }}>
+      <div style={{ marginBottom: '10px', display: 'flex', justifyContent: 'center', gap: '4px', flexWrap: 'wrap' }}>
+        {FOOTER_LINKS.map((link, i) => (
+          <span key={link} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <a href="#" className="flash-link" style={{ color: '#555', fontSize: '10px' }}>{link}</a>
+            {i < FOOTER_LINKS.length - 1 && <span style={{ color: '#222' }}>|</span>}
+          </span>
+        ))}
+      </div>
+      <div>&copy; 2025 Dada&apos;s Arcade &mdash; All Rights Reserved</div>
+      <div style={{ marginTop: '6px', color: '#333' }}>
+        No Flash Player Required &bull; HTML5 Powered &bull; Proudly from Palawan, Philippines
+      </div>
+      <div style={{ marginTop: '4px', color: '#252525', fontSize: '9px' }}>
+        Best viewed in Internet Explorer 6.0 at 1024&times;768 resolution
+      </div>
+    </footer>
+  );
+}
+
 export default function Home() {
   return (
-    <div className="w-full flex flex-col" style={{ backgroundColor: '#eeeeee' }}>
-      {/* Desktop: centered column layout, Mobile: full width */}
-      <div className="w-full flex flex-col items-center">
-        <GameContainer />
+    <div className="flash-site" style={{ minHeight: '100vh' }}>
+      {/* Flash header — desktop only */}
+      <div className="hidden md:block">
+        <FlashHeader />
+      </div>
+
+      {/* Breadcrumb */}
+      <div className="hidden md:block" style={{
+        background: '#1a1a1a',
+        borderBottom: '1px solid #2a2a2a',
+        padding: '5px 20px',
+        fontSize: '11px',
+        color: '#555',
+        fontFamily: 'Verdana, Arial, sans-serif',
+      }}>
+        <a href="#" className="flash-link">Home</a>
+        <span style={{ margin: '0 6px', color: '#333' }}>»</span>
+        <a href="#" className="flash-link">Games</a>
+        <span style={{ margin: '0 6px', color: '#333' }}>»</span>
+        <a href="#" className="flash-link">Action</a>
+        <span style={{ margin: '0 6px', color: '#333' }}>»</span>
+        <span>Dada&apos;s Ride Out</span>
+      </div>
+
+      {/* Game title bar */}
+      <div className="hidden md:block" style={{
+        padding: '12px 20px 8px',
+        background: '#1e1e1e',
+        borderBottom: '1px solid #2a2a2a',
+      }}>
+        <h1 style={{
+          fontFamily: 'Impact, "Arial Narrow", Arial, sans-serif',
+          fontSize: '28px',
+          color: '#ffffff',
+          textShadow: '2px 2px 0 #000, 0 0 30px rgba(232,102,10,0.35)',
+          margin: 0,
+          letterSpacing: '2px',
+          textTransform: 'uppercase',
+        }}>
+          Dada&apos;s Ride Out
+        </h1>
+        <div style={{ fontFamily: 'Verdana, Arial, sans-serif', fontSize: '11px', color: '#555', marginTop: '4px' }}>
+          A side-scrolling bike adventure through the streets of Palawan
+        </div>
+      </div>
+
+      {/* Game */}
+      <GameContainer />
+
+      {/* Info bar — desktop only */}
+      <div
+        className="hidden md:flex"
+        style={{
+          background: '#171717',
+          borderTop: '3px solid #e8660a',
+          borderBottom: '1px solid #2a2a2a',
+          padding: '10px 20px',
+          alignItems: 'center',
+          gap: '16px',
+          flexWrap: 'wrap',
+          fontFamily: 'Verdana, Arial, sans-serif',
+        }}
+      >
+        {/* Author */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: '140px' }}>
+          <div style={{
+            width: '34px', height: '34px',
+            background: 'linear-gradient(135deg, #e8660a, #ff9900)',
+            border: '1px solid rgba(255,153,0,0.3)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: '#fff', fontWeight: 'bold', fontSize: '16px',
+            fontFamily: 'Impact, sans-serif',
+            flexShrink: 0,
+          }}>D</div>
+          <div>
+            <div style={{ fontSize: '10px', color: '#555' }}>By</div>
+            <a href="#" className="flash-username" style={{ fontSize: '12px' }}>hmcldryl</a>
+          </div>
+        </div>
+
+        <div style={{ width: '1px', background: '#2a2a2a', alignSelf: 'stretch', minHeight: '30px' }} />
+
+        {/* Rating */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <div>
+            <div style={{ color: '#ffcc00', fontSize: '20px', lineHeight: '1', letterSpacing: '2px' }}>&#9733;&#9733;&#9733;&#9733;&#9734;</div>
+            <div style={{ color: '#555', fontSize: '10px', marginTop: '2px' }}>4.73 / 5.00 &nbsp;&middot;&nbsp; 12,847 votes</div>
+          </div>
+          <a href="#" className="flash-btn-orange" style={{ padding: '3px 8px' }}>Rate It!</a>
+        </div>
+
+        <div style={{ width: '1px', background: '#2a2a2a', alignSelf: 'stretch', minHeight: '30px' }} />
+
+        {/* Stats */}
+        <div style={{ display: 'flex', gap: '20px', fontSize: '11px', color: '#666' }}>
+          <span><strong style={{ color: '#aaa' }}>48,291</strong> Views</span>
+          <span><strong style={{ color: '#aaa' }}>1,024</strong> Favorites</span>
+          <span>Genre: <strong style={{ color: '#e8660a' }}>Action</strong></span>
+        </div>
+
+        <div style={{ width: '1px', background: '#2a2a2a', alignSelf: 'stretch', minHeight: '30px' }} />
+
+        {/* Tags */}
+        <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+          {GAME_TAGS.map((tag) => (
+            <a key={tag} href="#" className="flash-tag">{tag}</a>
+          ))}
+        </div>
+
+        <div style={{ flex: 1 }} />
+
+        {/* Actions */}
+        <div style={{ display: 'flex', gap: '4px' }}>
+          <a href="#" className="flash-btn-orange">&#9829; Favorite</a>
+          <a href="#" className="flash-btn-blue">&#8679; Share</a>
+          <a href="#" className="flash-btn-blue">&#8853; Embed</a>
+        </div>
+      </div>
+
+      {/* Details + comments */}
+      <div style={{ padding: '20px' }}>
         <GameDetails />
+
+        {/* Comments — desktop only */}
+        <div className="hidden md:block flash-panel" style={{ marginTop: '20px' }}>
+          <div className="flash-panel-header">
+            Comments
+            <span style={{ color: '#666', fontWeight: 'normal', marginLeft: '8px', fontSize: '10px' }}>(47)</span>
+          </div>
+
+          {/* Add comment row */}
+          <div style={{
+            background: '#1a1a1a',
+            padding: '10px 12px',
+            borderBottom: '1px solid #252525',
+            display: 'flex',
+            gap: '10px',
+            alignItems: 'center',
+          }}>
+            <div style={{
+              width: '36px', height: '36px',
+              background: '#252525',
+              border: '1px solid #3a3a3a',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: '#444', fontSize: '18px', flexShrink: 0,
+            }}>?</div>
+            <input
+              type="text"
+              placeholder="Log in to leave a comment..."
+              disabled
+              className="flash-input"
+              style={{ opacity: 0.4, cursor: 'not-allowed' }}
+            />
+          </div>
+
+          {FAKE_COMMENTS.map((comment) => (
+            <div key={comment.id} className="flash-comment-item">
+              <div style={{
+                width: '36px', height: '36px',
+                background: `linear-gradient(135deg, ${comment.avatarColor}66, ${comment.avatarColor})`,
+                border: `1px solid ${comment.avatarColor}44`,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: '#fff', fontWeight: 'bold', fontSize: '16px',
+                fontFamily: 'Impact, sans-serif',
+                flexShrink: 0,
+              }}>{comment.avatarLetter}</div>
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                  <a href="#" className="flash-username">{comment.username}</a>
+                  <span style={{ color: '#444', fontSize: '10px', fontFamily: 'Verdana, Arial, sans-serif' }}>Level {comment.level}</span>
+                  <span style={{ color: '#ffcc00', fontSize: '12px', letterSpacing: '1px' }}>
+                    {'★'.repeat(comment.stars)}{'☆'.repeat(5 - comment.stars)}
+                  </span>
+                  <span style={{ color: '#444', fontSize: '10px', marginLeft: 'auto', fontFamily: 'Verdana, Arial, sans-serif' }}>{comment.date}</span>
+                </div>
+                <div style={{ color: '#aaa', fontSize: '11px', marginTop: '5px', lineHeight: '1.6', fontFamily: 'Verdana, Arial, sans-serif' }}>
+                  {comment.text}
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* Load more */}
+          <div style={{
+            background: '#161616',
+            padding: '10px 12px',
+            borderTop: '1px solid #222',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+          }}>
+            <a href="#" className="flash-btn-blue" style={{ padding: '4px 16px' }}>Load More Comments</a>
+            <span style={{ color: '#444', fontSize: '10px', fontFamily: 'Verdana, Arial, sans-serif' }}>
+              Showing 4 of 47 comments
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Footer — desktop only */}
+      <div className="hidden md:block">
+        <FlashFooter />
       </div>
     </div>
   );


### PR DESCRIPTION
Wraps the game in a dark Newgrounds-style page — header with nav and category bar, breadcrumb, game title, rating/stats/tags info bar, comments section, footer. All Flash chrome is desktop-only; mobile keeps the existing full-screen game layout.

SpriteButton drops PNG state-sprites (normal/hover/pressed) in favour of CSS box-shadow bevel with isPressed state for reliable touch hold. DecorativeFrame replaces 9-slice PNG tiles with asymmetric border-color bevel + multi-ring box-shadow. Removes all runtime image fetches from the UI layer.