### PR TITLE
feat: account links section + dashboard guide improvements

### DIFF
--- a/app/components/nexus/AccountLinksSection.tsx
+++ b/app/components/nexus/AccountLinksSection.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { usePortfolio } from "@/lib/contexts/PortfolioContext";
+
+const COLOR_MAP = {
+  primary: {
+    border: "border-primary/20 hover:border-primary/60",
+    icon: "text-primary",
+    glow: "hover:shadow-[0_0_20px_rgba(207,188,255,0.1)]",
+    badge: "bg-primary/10 text-primary",
+  },
+  secondary: {
+    border: "border-secondary/20 hover:border-secondary/60",
+    icon: "text-secondary",
+    glow: "hover:shadow-[0_0_20px_rgba(205,192,233,0.1)]",
+    badge: "bg-secondary/10 text-secondary",
+  },
+  tertiary: {
+    border: "border-tertiary/20 hover:border-tertiary/60",
+    icon: "text-tertiary",
+    glow: "hover:shadow-[0_0_20px_rgba(231,195,101,0.1)]",
+    badge: "bg-tertiary/10 text-tertiary",
+  },
+} as const;
+
+type ColorKey = keyof typeof COLOR_MAP;
+
+export function AccountLinksSection() {
+  const { accountLinks } = usePortfolio();
+
+  if (!accountLinks?.length) return null;
+
+  return (
+    <section id="accounts" className="py-24 px-5 md:px-margin-desktop">
+      <div className="max-w-container-max mx-auto">
+        <div className="mb-16">
+          <h2 className="font-display text-4xl md:text-5xl font-bold text-on-surface mb-3">
+            Accounts
+          </h2>
+          <div className="w-24 h-[2px] bg-secondary" />
+          <p className="text-on-surface-variant font-body mt-4 text-sm">
+            Find me across platforms.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {accountLinks.map((link, i) => {
+            const colors = COLOR_MAP[(link.color as ColorKey) ?? "primary"] ?? COLOR_MAP.primary;
+            const Card = (
+              <div
+                className={`glass-panel rounded-xl p-6 border transition-all duration-200 group ${colors.border} ${colors.glow} flex items-center gap-4`}
+              >
+                <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${colors.badge} shrink-0`}>
+                  <span className={`material-symbols-outlined text-[22px] ${colors.icon}`}>
+                    {link.icon}
+                  </span>
+                </div>
+                <div className="min-w-0">
+                  <div className="font-mono text-[10px] tracking-[0.1em] uppercase text-on-surface-variant mb-1">
+                    {link.platform}
+                  </div>
+                  <div className="font-display font-semibold text-on-surface text-sm truncate">
+                    {link.handle}
+                  </div>
+                </div>
+                {link.url && (
+                  <span className={`material-symbols-outlined text-[16px] ml-auto opacity-0 group-hover:opacity-100 transition-opacity ${colors.icon}`}>
+                    arrow_outward
+                  </span>
+                )}
+              </div>
+            );
+
+            return link.url ? (
+              <a
+                key={i}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block"
+              >
+                {Card}
+              </a>
+            ) : (
+              <div key={i}>{Card}</div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/components/nexus/ConnectSection.tsx
+++ b/app/components/nexus/ConnectSection.tsx
@@ -9,14 +9,16 @@ export function ConnectSection() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const data = new FormData(e.currentTarget);
-    const name = data.get("name") as string;
-    const message = data.get("message") as string;
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get("name") as string;
+    const email = formData.get("email") as string;
+    const message = formData.get("message") as string;
     const subject = encodeURIComponent(`Nexus // Contact from ${name}`);
-    const body = encodeURIComponent(message);
+    const body = encodeURIComponent(`From: ${name} <${email}>\n\n${message}`);
     window.location.href = `mailto:${personalInfo.email}?subject=${subject}&body=${body}`;
     setStatus("sent");
     (e.target as HTMLFormElement).reset();
+    setTimeout(() => setStatus("idle"), 4000);
   };
 
   return (

--- a/app/components/nexus/HeroSection.tsx
+++ b/app/components/nexus/HeroSection.tsx
@@ -27,7 +27,14 @@ export function HeroSection() {
       const line = TERMINAL_LINES[i];
       const div = document.createElement("div");
       div.className = "flex gap-3 opacity-0 translate-y-1 transition-all duration-500";
-      div.innerHTML = `<span class="text-primary opacity-40">$</span><span class="${line.color}">${line.text}</span>`;
+      const prefix = document.createElement("span");
+      prefix.className = "text-primary opacity-40";
+      prefix.textContent = "$";
+      const text = document.createElement("span");
+      text.className = line.color;
+      text.textContent = line.text;
+      div.appendChild(prefix);
+      div.appendChild(text);
       if (cursor) terminal.insertBefore(div, cursor);
       requestAnimationFrame(() => div.classList.remove("opacity-0", "translate-y-1"));
       i++;

--- a/app/components/nexus/QuestSection.tsx
+++ b/app/components/nexus/QuestSection.tsx
@@ -58,7 +58,7 @@ export function QuestSection() {
                   <span className="material-symbols-outlined text-[80px] text-primary">memory</span>
                 </div>
                 <div className="flex gap-2 mb-4 flex-wrap">
-                  {big.tags.map((t) => <Tag key={t} label={t} />)}
+                  {big.tags.map((t, i) => <Tag key={`${t}-${i}`} label={t} />)}
                 </div>
                 <h3 className="font-display text-2xl font-semibold text-on-surface mb-2">
                   {big.name}
@@ -95,7 +95,7 @@ export function QuestSection() {
                   <span className="material-symbols-outlined text-[80px] text-tertiary">smartphone</span>
                 </div>
                 <div className="flex gap-2 mb-4 flex-wrap">
-                  {small.tags.map((t) => <Tag key={t} label={t} />)}
+                  {small.tags.map((t, i) => <Tag key={`${t}-${i}`} label={t} />)}
                 </div>
                 <h3 className="font-display text-xl font-semibold text-on-surface mb-2">
                   {small.name}
@@ -133,7 +133,7 @@ export function QuestSection() {
                 </div>
                 <div className="max-w-2xl">
                   <div className="flex gap-2 mb-4 flex-wrap">
-                    {wide.tags.map((t) => <Tag key={t} label={t} />)}
+                    {wide.tags.map((t, i) => <Tag key={`${t}-${i}`} label={t} />)}
                   </div>
                   <h3 className="font-display text-3xl md:text-4xl font-bold text-on-surface mb-4">
                     {wide.name}
@@ -170,7 +170,7 @@ export function QuestSection() {
               <div className="absolute inset-0 glass-panel" />
               <div className="relative h-full p-8 flex flex-col justify-end min-h-[300px]">
                 <div className="flex gap-2 mb-4 flex-wrap">
-                  {project.tags.map((t) => <Tag key={t} label={t} />)}
+                  {project.tags.map((t, i) => <Tag key={`${t}-${i}`} label={t} />)}
                 </div>
                 <h3 className="font-display text-xl font-semibold text-on-surface mb-2">
                   {project.name}

--- a/app/components/nexus/SideNav.tsx
+++ b/app/components/nexus/SideNav.tsx
@@ -3,6 +3,7 @@ const NAV_LINKS = [
   { id: "arsenal", label: "Arsenal", icon: "swords" },
   { id: "quests", label: "Quests", icon: "task_alt" },
   { id: "experience", label: "Experience", icon: "military_tech" },
+  { id: "accounts", label: "Accounts", icon: "manage_accounts" },
   { id: "connect", label: "Connect", icon: "alternate_email" },
 ];
 

--- a/app/components/nexus/TopNav.tsx
+++ b/app/components/nexus/TopNav.tsx
@@ -7,6 +7,7 @@ const NAV_LINKS = [
   { id: "arsenal", label: "Arsenal" },
   { id: "quests", label: "Quests" },
   { id: "experience", label: "Experience" },
+  { id: "accounts", label: "Accounts" },
   { id: "connect", label: "Connect" },
 ];
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -46,6 +46,128 @@ const inputCls =
 const selectCls =
   "bg-surface-container border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface font-mono text-[12px] focus:border-primary outline-none";
 
+const COLOR_SWATCHES = {
+  primary:   { hex: "#cfbcff", label: "Primary (lavender)" },
+  secondary: { hex: "#cdc0e9", label: "Secondary (muted purple)" },
+  tertiary:  { hex: "#e7c365", label: "Tertiary (gold)" },
+} as const;
+
+function ColorSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {(Object.keys(COLOR_SWATCHES) as Array<keyof typeof COLOR_SWATCHES>).map((key) => {
+        const { hex, label } = COLOR_SWATCHES[key];
+        const active = value === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            title={label}
+            onClick={() => onChange(key)}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg border font-mono text-[11px] transition-all ${
+              active
+                ? "border-on-surface/60 bg-surface-container-high text-on-surface shadow-[0_0_8px_rgba(255,255,255,0.05)]"
+                : "border-outline-variant/30 text-on-surface-variant hover:border-outline-variant/60"
+            }`}
+          >
+            <span
+              className="w-3 h-3 rounded-full shrink-0 shadow-sm"
+              style={{ backgroundColor: hex, boxShadow: active ? `0 0 8px ${hex}80` : undefined }}
+            />
+            {key}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+const SIZE_INFO = {
+  big:   { cols: "8/12", desc: "Large feature card (left side)" },
+  small: { cols: "4/12", desc: "Compact card (right side)" },
+  wide:  { cols: "12/12", desc: "Full-width banner card" },
+  other: { cols: "6/12", desc: "Half-width card (extras)" },
+} as const;
+
+function SizeSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-2">
+        {(Object.keys(SIZE_INFO) as Array<keyof typeof SIZE_INFO>).map((key) => {
+          const { cols } = SIZE_INFO[key];
+          const active = value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onChange(key)}
+              className={`flex items-center gap-2 px-3 py-2 rounded-lg border font-mono text-[11px] transition-all ${
+                active
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-outline-variant/30 text-on-surface-variant hover:border-outline-variant/60"
+              }`}
+            >
+              {key}
+              <span className={`text-[10px] opacity-60`}>{cols}</span>
+            </button>
+          );
+        })}
+      </div>
+      {value in SIZE_INFO && (
+        <p className="font-mono text-[10px] text-on-surface-variant/60">
+          {SIZE_INFO[value as keyof typeof SIZE_INFO].desc}
+        </p>
+      )}
+    </div>
+  );
+}
+
+const ICON_GROUPS = [
+  { label: "Tech", icons: ["code", "terminal", "hub", "memory", "storage", "cloud", "android", "smartphone", "settings", "account_tree"] },
+  { label: "Social", icons: ["person", "alternate_email", "link", "manage_accounts", "forum"] },
+  { label: "Gaming", icons: ["sports_esports", "videogame_asset", "military_tech", "swords"] },
+  { label: "Work", icons: ["work", "school", "rocket_launch", "palette", "task_alt", "business_center"] },
+] as const;
+
+function IconReference({ onPick }: { onPick: (icon: string) => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="font-mono text-[10px] text-on-surface-variant/60 hover:text-primary transition-colors flex items-center gap-1"
+      >
+        <span className="material-symbols-outlined text-[13px]">{open ? "expand_less" : "expand_more"}</span>
+        {open ? "hide icon reference" : "browse common icons"}
+      </button>
+      {open && (
+        <div className="mt-2 glass-panel rounded-xl p-4 border border-outline-variant/20 space-y-3">
+          {ICON_GROUPS.map((group) => (
+            <div key={group.label}>
+              <div className="font-mono text-[10px] text-on-surface-variant/50 mb-2 uppercase tracking-[0.08em]">{group.label}</div>
+              <div className="flex flex-wrap gap-2">
+                {group.icons.map((icon) => (
+                  <button
+                    key={icon}
+                    type="button"
+                    title={icon}
+                    onClick={() => { onPick(icon); setOpen(false); }}
+                    className="flex flex-col items-center gap-1 p-2 rounded-lg bg-surface-container hover:bg-surface-container-high hover:text-primary text-on-surface-variant transition-all border border-transparent hover:border-primary/30"
+                  >
+                    <span className="material-symbols-outlined text-[20px]">{icon}</span>
+                    <span className="font-mono text-[9px] opacity-60">{icon}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Skill row ────────────────────────────────────────────────────────────────
 
 function SkillRow({
@@ -101,37 +223,35 @@ function SkillRow({
             onChange={(e) => upd("name", e.target.value)}
           />
         </Field>
-        <div className="grid grid-cols-2 gap-4">
-          <Field label="Level (0-100)">
+        <Field label="Level (0-100)">
+          <div className="space-y-2">
             <input
-              type="number"
+              type="range"
               min={0}
               max={100}
-              className={inputCls}
               value={skill.level}
               onChange={(e) => upd("level", Number(e.target.value))}
+              className="w-full accent-[#cfbcff]"
             />
-          </Field>
-          <Field label="Color">
-            <select
-              className={selectCls}
-              value={skill.color}
-              onChange={(e) => upd("color", e.target.value)}
-            >
-              {COLOR_OPTIONS.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </select>
-          </Field>
-        </div>
+            <div className="flex justify-between font-mono text-[10px] text-on-surface-variant/60">
+              <span>0</span>
+              <span className="text-primary font-bold">{skill.level}</span>
+              <span>100</span>
+            </div>
+          </div>
+        </Field>
       </div>
-      <Field label="Icon (Material Symbols name)">
+      <Field label="Color">
+        <ColorSelect value={skill.color} onChange={(v) => upd("color", v)} />
+      </Field>
+      <Field label="Icon">
         <input
           className={inputCls}
           value={skill.icon}
           onChange={(e) => upd("icon", e.target.value)}
           placeholder="e.g. code, smartphone, memory"
         />
+        <IconReference onPick={(icon) => upd("icon", icon)} />
       </Field>
       <Field label="Description">
         <input
@@ -184,19 +304,16 @@ function ProjectRow({
         <Field label="Name">
           <input className={inputCls} value={project.name} onChange={(e) => upd("name", e.target.value)} />
         </Field>
-        <div className="grid grid-cols-2 gap-4">
-          <Field label="Size">
-            <select className={selectCls} value={project.size} onChange={(e) => upd("size", e.target.value)}>
-              {SIZE_OPTIONS.map((s) => <option key={s} value={s}>{s}</option>)}
-            </select>
-          </Field>
-          <Field label="Accent color">
-            <select className={selectCls} value={project.accentColor} onChange={(e) => upd("accentColor", e.target.value)}>
-              {COLOR_OPTIONS.map((c) => <option key={c} value={c}>{c}</option>)}
-            </select>
-          </Field>
-        </div>
+        <Field label="Link (optional)">
+          <input className={inputCls} value={project.link ?? ""} placeholder="https://..." onChange={(e) => upd("link", e.target.value || null)} />
+        </Field>
       </div>
+      <Field label="Size">
+        <SizeSelect value={project.size} onChange={(v) => upd("size", v)} />
+      </Field>
+      <Field label="Accent color">
+        <ColorSelect value={project.accentColor} onChange={(v) => upd("accentColor", v)} />
+      </Field>
       <Field label="Description">
         <textarea
           className={`${inputCls} resize-none`}
@@ -205,25 +322,16 @@ function ProjectRow({
           onChange={(e) => upd("description", e.target.value)}
         />
       </Field>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <Field label="Tags (comma-separated)">
-          <input
-            className={inputCls}
-            value={project.tags.join(", ")}
-            onChange={(e) =>
-              upd("tags", e.target.value.split(",").map((t) => t.trim()).filter(Boolean))
-            }
-          />
-        </Field>
-        <Field label="Link (optional)">
-          <input
-            className={inputCls}
-            value={project.link ?? ""}
-            placeholder="https://..."
-            onChange={(e) => upd("link", e.target.value || null)}
-          />
-        </Field>
-      </div>
+      <Field label="Tags (comma-separated)">
+        <input
+          className={inputCls}
+          value={project.tags.join(", ")}
+          onChange={(e) =>
+            upd("tags", e.target.value.split(",").map((t) => t.trim()).filter(Boolean))
+          }
+          placeholder="e.g. IoT, Mobile, Flutter"
+        />
+      </Field>
     </div>
   );
 }
@@ -272,19 +380,16 @@ function ExperienceRow({
           <input className={inputCls} value={item.company} onChange={(e) => upd("company", e.target.value)} />
         </Field>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <Field label="Period">
-          <input className={inputCls} value={item.period} onChange={(e) => upd("period", e.target.value)} />
-        </Field>
-        <Field label="Color">
-          <select className={selectCls} value={item.color} onChange={(e) => upd("color", e.target.value)}>
-            {COLOR_OPTIONS.map((c) => <option key={c} value={c}>{c}</option>)}
-          </select>
-        </Field>
-        <Field label="Icon">
-          <input className={inputCls} value={item.icon} onChange={(e) => upd("icon", e.target.value)} placeholder="e.g. terminal" />
-        </Field>
-      </div>
+      <Field label="Period">
+        <input className={inputCls} value={item.period} onChange={(e) => upd("period", e.target.value)} placeholder="e.g. Jan 2024 – Present" />
+      </Field>
+      <Field label="Color">
+        <ColorSelect value={item.color} onChange={(v) => upd("color", v)} />
+      </Field>
+      <Field label="Icon">
+        <input className={inputCls} value={item.icon} onChange={(e) => upd("icon", e.target.value)} placeholder="e.g. terminal" />
+        <IconReference onPick={(icon) => upd("icon", icon)} />
+      </Field>
       <Field label="Description">
         <textarea
           className={`${inputCls} resize-none`}
@@ -341,19 +446,16 @@ function AccountLinkRow({
           <input className={inputCls} value={link.handle} onChange={(e) => upd("handle", e.target.value)} placeholder="e.g. hmcldryl or SW-1234-5678-9012" />
         </Field>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <Field label="URL (optional)">
-          <input className={inputCls} value={link.url ?? ""} placeholder="https://..." onChange={(e) => upd("url", e.target.value || null)} />
-        </Field>
-        <Field label="Icon (Material Symbols)">
-          <input className={inputCls} value={link.icon} onChange={(e) => upd("icon", e.target.value)} placeholder="e.g. sports_esports" />
-        </Field>
-        <Field label="Color">
-          <select className={selectCls} value={link.color} onChange={(e) => upd("color", e.target.value)}>
-            {COLOR_OPTIONS.map((c) => <option key={c} value={c}>{c}</option>)}
-          </select>
-        </Field>
-      </div>
+      <Field label="URL (optional)">
+        <input className={inputCls} value={link.url ?? ""} placeholder="https://..." onChange={(e) => upd("url", e.target.value || null)} />
+      </Field>
+      <Field label="Color">
+        <ColorSelect value={link.color} onChange={(v) => upd("color", v)} />
+      </Field>
+      <Field label="Icon">
+        <input className={inputCls} value={link.icon} onChange={(e) => upd("icon", e.target.value)} placeholder="e.g. sports_esports" />
+        <IconReference onPick={(icon) => upd("icon", icon)} />
+      </Field>
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -567,7 +567,7 @@ export default function Dashboard() {
               <div className="space-y-4">
                 {data.skills.map((skill, idx) => (
                   <SkillRow
-                    key={idx}
+                    key={`${idx}-${skill.name}`}
                     skill={skill}
                     idx={idx}
                     total={data.skills.length}
@@ -601,7 +601,7 @@ export default function Dashboard() {
               <div className="space-y-4">
                 {data.projects.map((project, idx) => (
                   <ProjectRow
-                    key={idx}
+                    key={`${idx}-${project.name}`}
                     project={project}
                     idx={idx}
                     total={data.projects.length}
@@ -630,7 +630,7 @@ export default function Dashboard() {
               <div className="space-y-4">
                 {data.experience.map((item, idx) => (
                   <ExperienceRow
-                    key={idx}
+                    key={`${idx}-${item.role}`}
                     item={item}
                     idx={idx}
                     total={data.experience.length}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,9 +13,10 @@ import {
   type Skill,
   type Project,
   type Experience,
+  type AccountLink,
 } from "@/lib/firestore";
 
-type Tab = "info" | "skills" | "projects" | "experience";
+type Tab = "info" | "skills" | "projects" | "experience" | "accounts";
 
 const COLOR_OPTIONS = ["primary", "secondary", "tertiary"] as const;
 const SIZE_OPTIONS = ["big", "small", "wide", "other"] as const;
@@ -296,6 +297,67 @@ function ExperienceRow({
   );
 }
 
+// ─── Account link row ─────────────────────────────────────────────────────────
+
+function AccountLinkRow({
+  link,
+  idx,
+  total,
+  onChange,
+  onMove,
+  onDelete,
+}: {
+  link: AccountLink;
+  idx: number;
+  total: number;
+  onChange: (idx: number, updated: AccountLink) => void;
+  onMove: (idx: number, dir: -1 | 1) => void;
+  onDelete: (idx: number) => void;
+}) {
+  const upd = (field: keyof AccountLink, val: string | null) =>
+    onChange(idx, { ...link, [field]: val });
+
+  return (
+    <div className="glass-panel rounded-xl p-5 border border-outline-variant/20 space-y-4">
+      <div className="flex justify-between items-center">
+        <span className="font-mono text-[11px] text-on-surface-variant">LINK #{idx + 1}</span>
+        <div className="flex gap-2">
+          <button onClick={() => onMove(idx, -1)} disabled={idx === 0} className="text-on-surface-variant hover:text-primary disabled:opacity-30 transition-colors">
+            <span className="material-symbols-outlined text-[18px]">arrow_upward</span>
+          </button>
+          <button onClick={() => onMove(idx, 1)} disabled={idx === total - 1} className="text-on-surface-variant hover:text-primary disabled:opacity-30 transition-colors">
+            <span className="material-symbols-outlined text-[18px]">arrow_downward</span>
+          </button>
+          <button onClick={() => onDelete(idx)} className="text-error hover:brightness-125 transition-colors">
+            <span className="material-symbols-outlined text-[18px]">delete</span>
+          </button>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Field label="Platform">
+          <input className={inputCls} value={link.platform} onChange={(e) => upd("platform", e.target.value)} placeholder="e.g. Steam, Nintendo Switch" />
+        </Field>
+        <Field label="Handle / Username / Friend Code">
+          <input className={inputCls} value={link.handle} onChange={(e) => upd("handle", e.target.value)} placeholder="e.g. hmcldryl or SW-1234-5678-9012" />
+        </Field>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Field label="URL (optional)">
+          <input className={inputCls} value={link.url ?? ""} placeholder="https://..." onChange={(e) => upd("url", e.target.value || null)} />
+        </Field>
+        <Field label="Icon (Material Symbols)">
+          <input className={inputCls} value={link.icon} onChange={(e) => upd("icon", e.target.value)} placeholder="e.g. sports_esports" />
+        </Field>
+        <Field label="Color">
+          <select className={selectCls} value={link.color} onChange={(e) => upd("color", e.target.value)}>
+            {COLOR_OPTIONS.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </Field>
+      </div>
+    </div>
+  );
+}
+
 // ─── Main dashboard ──────────────────────────────────────────────────────────
 
 export default function Dashboard() {
@@ -410,11 +472,35 @@ export default function Dashboard() {
       }
     );
 
+  // ── Account link helpers ──
+  const updateAccountLink = (idx: number, updated: AccountLink) =>
+    setData((d) => d && { ...d, accountLinks: d.accountLinks.map((l, i) => (i === idx ? updated : l)) });
+  const moveAccountLink = (idx: number, dir: -1 | 1) =>
+    setData((d) => {
+      if (!d) return d;
+      const arr = [...d.accountLinks];
+      [arr[idx], arr[idx + dir]] = [arr[idx + dir], arr[idx]];
+      return { ...d, accountLinks: arr };
+    });
+  const deleteAccountLink = (idx: number) =>
+    setData((d) => d && { ...d, accountLinks: d.accountLinks.filter((_, i) => i !== idx) });
+  const addAccountLink = () =>
+    setData((d) =>
+      d && {
+        ...d,
+        accountLinks: [
+          ...d.accountLinks,
+          { platform: "New Platform", handle: "", url: null, icon: "link", color: "primary" },
+        ],
+      }
+    );
+
   const TABS: { id: Tab; label: string; icon: string }[] = [
     { id: "info", label: "Personal Info", icon: "person" },
     { id: "skills", label: "Arsenal", icon: "swords" },
     { id: "projects", label: "Quest Log", icon: "task_alt" },
     { id: "experience", label: "Experience", icon: "military_tech" },
+    { id: "accounts", label: "Accounts", icon: "manage_accounts" },
   ];
 
   if (!ready || !data) {
@@ -637,6 +723,40 @@ export default function Dashboard() {
                     onChange={updateExp}
                     onMove={moveExp}
                     onDelete={deleteExp}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Accounts */}
+          {tab === "accounts" && (
+            <div className="space-y-4">
+              <div className="flex justify-between items-center">
+                <h2 className="font-display text-2xl font-bold text-on-surface">Accounts ({data.accountLinks.length})</h2>
+                <button
+                  onClick={addAccountLink}
+                  className="flex items-center gap-2 bg-surface-container-high border border-outline-variant/30 text-on-surface font-mono text-[11px] uppercase tracking-[0.08em] py-2 px-4 rounded-lg hover:border-primary hover:text-primary transition-all"
+                >
+                  <span className="material-symbols-outlined text-[16px]">add</span>
+                  ADD ACCOUNT
+                </button>
+              </div>
+              <div className="glass-panel rounded-xl p-4 border border-secondary/20 mb-2">
+                <p className="font-mono text-[11px] text-secondary">
+                  Leave URL empty for accounts with no link (e.g. Nintendo Switch friend codes).
+                </p>
+              </div>
+              <div className="space-y-4">
+                {data.accountLinks.map((link, idx) => (
+                  <AccountLinkRow
+                    key={`${idx}-${link.platform}`}
+                    link={link}
+                    idx={idx}
+                    total={data.accountLinks.length}
+                    onChange={updateAccountLink}
+                    onMove={moveAccountLink}
+                    onDelete={deleteAccountLink}
                   />
                 ))}
               </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { ArsenalSection } from "./components/nexus/ArsenalSection";
 import { QuestSection } from "./components/nexus/QuestSection";
 import { ExperienceSection } from "./components/nexus/ExperienceSection";
 import { ConnectSection } from "./components/nexus/ConnectSection";
+import { AccountLinksSection } from "./components/nexus/AccountLinksSection";
 
 function Footer() {
   return (
@@ -58,6 +59,7 @@ export default function Home() {
         <ArsenalSection />
         <QuestSection />
         <ExperienceSection />
+        <AccountLinksSection />
         <ConnectSection />
         <Footer />
       </main>

--- a/content/portfolio.json
+++ b/content/portfolio.json
@@ -91,6 +91,36 @@
       "accentColor": "tertiary"
     }
   ],
+  "accountLinks": [
+    {
+      "platform": "GitHub",
+      "handle": "hmcldryl",
+      "url": "https://github.com/hmcldryl",
+      "icon": "code",
+      "color": "primary"
+    },
+    {
+      "platform": "LinkedIn",
+      "handle": "hmcldryl",
+      "url": "https://linkedin.com/in/hmcldryl",
+      "icon": "person",
+      "color": "secondary"
+    },
+    {
+      "platform": "Steam",
+      "handle": "hmcldryl",
+      "url": "https://steamcommunity.com/id/hmcldryl",
+      "icon": "sports_esports",
+      "color": "tertiary"
+    },
+    {
+      "platform": "Nintendo Switch",
+      "handle": "SW-XXXX-XXXX-XXXX",
+      "url": null,
+      "icon": "videogame_asset",
+      "color": "primary"
+    }
+  ],
   "experience": [
     {
       "role": "Software Engineer",

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -12,6 +12,7 @@ export type PersonalInfo = typeof rawData.personalInfo;
 export type Skill = (typeof rawData.skills)[0];
 export type Project = (typeof rawData.projects)[0];
 export type Experience = (typeof rawData.experience)[0];
+export type AccountLink = (typeof rawData.accountLinks)[0];
 export type PortfolioData = typeof rawData;
 
 const NOOP: Unsubscribe = () => {};


### PR DESCRIPTION
## Summary

- Add Accounts section to portfolio (Steam, Nintendo Switch, GitHub, LinkedIn, etc.)
- Add Accounts tab to dashboard CMS with full add/edit/delete/reorder
- Dashboard UX: color swatches with glow preview, skill level slider, size button group with layout hints, icon picker with categorized visual grid
- Codebase cleanup: stable React keys, remove innerHTML, wire contact form email field, auto-reset sent status

## Test plan

- [ ] Accounts section renders on live site between Experience and Connect
- [ ] Dashboard Accounts tab: add/edit/delete/reorder, URL optional for friend codes
- [ ] Color swatches show lavender/purple/gold previews with glow on active
- [ ] Icon picker expands, clicking fills input and closes
- [ ] Skill level slider updates live number readout

Generated with [Claude Code](https://claude.com/claude-code)
