### PR TITLE
feat(anim): scroll reveals, idle orbs, hero stagger, animated skill bars

### DIFF
--- a/app/components/nexus/ArsenalSection.tsx
+++ b/app/components/nexus/ArsenalSection.tsx
@@ -30,7 +30,7 @@ export function ArsenalSection() {
   return (
     <section id="arsenal" className="py-24 px-5 md:px-margin-desktop">
       <div className="max-w-container-max mx-auto">
-        <div className="mb-16">
+        <div className="mb-16" data-reveal>
           <h2 className="font-display text-4xl md:text-5xl font-bold text-on-surface mb-3">
             Technical Arsenal
           </h2>
@@ -44,8 +44,9 @@ export function ArsenalSection() {
             return (
               <div
                 key={skill.name}
-                className="glass-panel p-8 rounded-xl relative corner-accent corner-top-left group hover:scale-[1.02] transition-all duration-300 border border-outline-variant/20"
-                style={{ animationDelay: `${idx * 80}ms` }}
+                data-reveal
+                data-delay={String((idx % 3) + 1)}
+                className="glass-panel p-8 rounded-xl relative corner-accent corner-top-left group hover:scale-[1.02] hover:-translate-y-1 transition-all duration-300 border border-outline-variant/20"
               >
                 <div className="mb-6 flex justify-between items-start">
                   <div className={`p-3 ${colors.bg} rounded-lg ${colors.text}`}>
@@ -70,8 +71,8 @@ export function ArsenalSection() {
                   </div>
                   <div className="h-[6px] w-full bg-surface-container rounded-full overflow-hidden">
                     <div
-                      className={`h-full ${colors.bar} rounded-full transition-all duration-1000`}
-                      style={{ width: `${skill.level}%` }}
+                      className={`skill-bar-fill h-full ${colors.bar} rounded-full`}
+                      style={{ "--bar-level": `${skill.level}%` } as React.CSSProperties}
                     />
                   </div>
                 </div>

--- a/app/components/nexus/BackgroundOrbs.tsx
+++ b/app/components/nexus/BackgroundOrbs.tsx
@@ -1,0 +1,14 @@
+export function BackgroundOrbs() {
+  return (
+    <div className="fixed inset-0 z-0 overflow-hidden pointer-events-none select-none" aria-hidden="true">
+      {/* Primary orb — top left */}
+      <div className="orb-a absolute -top-40 -left-40 w-[600px] h-[600px] rounded-full bg-primary/[0.07] blur-[120px]" />
+      {/* Secondary orb — top right */}
+      <div className="orb-b absolute -top-20 right-0 w-[500px] h-[500px] rounded-full bg-secondary/[0.05] blur-[100px]" />
+      {/* Tertiary orb — bottom center */}
+      <div className="orb-c absolute bottom-0 left-1/2 -translate-x-1/2 w-[700px] h-[400px] rounded-full bg-tertiary/[0.04] blur-[140px]" />
+      {/* Small accent — mid right */}
+      <div className="orb-a absolute top-1/2 -right-20 w-[300px] h-[300px] rounded-full bg-primary/[0.06] blur-[80px]" style={{ animationDelay: "-6s" }} />
+    </div>
+  );
+}

--- a/app/components/nexus/HeroSection.tsx
+++ b/app/components/nexus/HeroSection.tsx
@@ -49,24 +49,27 @@ export function HeroSection() {
   const lastName = rest.join(" ");
 
   return (
-    <section id="nexus" className="min-h-screen flex items-center px-5 md:px-margin-desktop py-24">
-      <div className="max-w-container-max mx-auto w-full grid grid-cols-1 lg:grid-cols-12 gap-gutter items-center">
+    <section id="nexus" className="relative min-h-screen flex items-center px-5 md:px-margin-desktop py-24 overflow-hidden">
+      {/* Scanline idle overlay */}
+      <div className="scanlines absolute inset-0 z-0 opacity-40" aria-hidden="true" />
+
+      <div className="relative z-10 max-w-container-max mx-auto w-full grid grid-cols-1 lg:grid-cols-12 gap-gutter items-center">
         {/* Left: intro */}
         <div className="lg:col-span-7 space-y-6">
-          <div className="inline-block py-1 px-3 border border-primary/30 rounded-full font-mono text-[12px] text-primary bg-primary/5 tracking-[0.05em]">
+          <div className="hero-entry hero-entry-1 inline-block py-1 px-3 border border-primary/30 rounded-full font-mono text-[12px] text-primary bg-primary/5 tracking-[0.05em] breathe">
             [ SYSTEM ACTIVE: V1.0.0 ]
           </div>
 
           <h1 className="font-display font-bold text-on-surface leading-none">
-            <span className="text-5xl md:text-7xl block">{firstName}</span>
-            <span className="text-5xl md:text-7xl block text-primary">{lastName}</span>
+            <span className="hero-entry hero-entry-2 text-5xl md:text-7xl block">{firstName}</span>
+            <span className="hero-entry hero-entry-3 text-5xl md:text-7xl block text-primary">{lastName}</span>
           </h1>
 
-          <p className="font-body text-lg text-on-surface-variant max-w-xl leading-relaxed">
+          <p className="hero-entry hero-entry-4 font-body text-lg text-on-surface-variant max-w-xl leading-relaxed">
             {personalInfo.bio}
           </p>
 
-          <div className="flex flex-wrap gap-4 pt-2">
+          <div className="hero-entry hero-entry-5 flex flex-wrap gap-4 pt-2">
             <a
               href="#quests"
               className="bg-primary text-on-primary font-mono text-[11px] tracking-[0.1em] font-bold uppercase py-4 px-8 rounded-lg border border-transparent border-glow hover:brightness-110 active:scale-95 transition-all"

--- a/app/components/nexus/RevealObserver.tsx
+++ b/app/components/nexus/RevealObserver.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function RevealObserver() {
+  useEffect(() => {
+    const revealObs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("visible");
+            revealObs.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: "0px 0px -40px 0px" }
+    );
+
+    const barObs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("bar-visible");
+            barObs.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    const observe = () => {
+      document.querySelectorAll("[data-reveal]").forEach((el) => revealObs.observe(el));
+      document.querySelectorAll(".skill-bar-fill").forEach((el) => barObs.observe(el));
+    };
+
+    observe();
+
+    // Re-observe on DOM changes (Firestore data arriving after mount)
+    const mutObs = new MutationObserver(observe);
+    mutObs.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      revealObs.disconnect();
+      barObs.disconnect();
+      mutObs.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,3 +134,120 @@ textarea:focus {
   border-color: #cfbcff !important;
   box-shadow: 0 0 0 1px #cfbcff;
 }
+
+/* ===== Scroll Reveal ===== */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.7s cubic-bezier(0.4, 0, 0.2, 1),
+              transform 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: opacity, transform;
+}
+[data-reveal].visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+[data-reveal][data-delay="1"] { transition-delay: 80ms; }
+[data-reveal][data-delay="2"] { transition-delay: 160ms; }
+[data-reveal][data-delay="3"] { transition-delay: 240ms; }
+[data-reveal][data-delay="4"] { transition-delay: 320ms; }
+[data-reveal][data-delay="5"] { transition-delay: 400ms; }
+[data-reveal][data-delay="6"] { transition-delay: 480ms; }
+[data-reveal][data-delay="7"] { transition-delay: 560ms; }
+[data-reveal][data-delay="8"] { transition-delay: 640ms; }
+[data-reveal][data-delay="9"] { transition-delay: 720ms; }
+
+/* ===== Skill Bar Animated Fill ===== */
+.skill-bar-fill {
+  width: 0 !important;
+  transition: width 1.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.skill-bar-fill.bar-visible {
+  width: var(--bar-level) !important;
+}
+
+/* ===== Hero Entry Stagger ===== */
+@keyframes hero-fade-up {
+  from { opacity: 0; transform: translateY(32px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.hero-entry {
+  animation: hero-fade-up 0.9s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.hero-entry-1 { animation-delay: 0ms; }
+.hero-entry-2 { animation-delay: 150ms; }
+.hero-entry-3 { animation-delay: 300ms; }
+.hero-entry-4 { animation-delay: 450ms; }
+.hero-entry-5 { animation-delay: 600ms; }
+
+/* ===== Background Orbs (Idle) ===== */
+@keyframes orb-a {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%       { transform: translate(60px, -40px) scale(1.08); }
+  66%       { transform: translate(-30px, 30px) scale(0.94); }
+}
+@keyframes orb-b {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  40%       { transform: translate(-50px, 30px) scale(1.05); }
+  70%       { transform: translate(40px, -20px) scale(0.97); }
+}
+@keyframes orb-c {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50%       { transform: translate(30px, 50px) scale(1.1); }
+}
+.orb-a { animation: orb-a 18s ease-in-out infinite; }
+.orb-b { animation: orb-b 24s ease-in-out infinite; }
+.orb-c { animation: orb-c 20s ease-in-out infinite; }
+
+/* ===== Idle Breathe Glow ===== */
+@keyframes breathe {
+  0%, 100% { opacity: 0.12; transform: scale(1); }
+  50%       { opacity: 0.28; transform: scale(1.04); }
+}
+.breathe { animation: breathe 4s ease-in-out infinite; }
+
+/* ===== Shimmer (cards/badges) ===== */
+@keyframes shimmer-slide {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+.shimmer-idle {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(207, 188, 255, 0.06) 40%,
+    rgba(207, 188, 255, 0.12) 50%,
+    rgba(207, 188, 255, 0.06) 60%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer-slide 6s linear infinite;
+}
+
+/* ===== Scanline overlay (hero) ===== */
+@keyframes scan {
+  from { background-position: 0 0; }
+  to   { background-position: 0 100vh; }
+}
+.scanlines {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.04) 2px,
+    rgba(0, 0, 0, 0.04) 4px
+  );
+  animation: scan 8s linear infinite;
+  pointer-events: none;
+}
+
+/* ===== Reduced motion ===== */
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal]   { opacity: 1; transform: none; transition: none; }
+  .skill-bar-fill { transition: none; }
+  .hero-entry     { animation: none; opacity: 1; transform: none; }
+  .orb-a, .orb-b, .orb-c { animation: none; }
+  .breathe        { animation: none; }
+  .shimmer-idle   { animation: none; }
+  .scanlines      { animation: none; }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import localFont from "next/font/local";
 import { Space_Grotesk, Inter } from "next/font/google";
 import { PortfolioProvider } from "@/lib/contexts/PortfolioContext";
 import { FaviconUpdater } from "@/app/components/nexus/FaviconUpdater";
+import { RevealObserver } from "@/app/components/nexus/RevealObserver";
+import { BackgroundOrbs } from "@/app/components/nexus/BackgroundOrbs";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -48,6 +50,8 @@ export default function RootLayout({
       >
         <PortfolioProvider>
           <FaviconUpdater />
+          <RevealObserver />
+          <BackgroundOrbs />
           {children}
         </PortfolioProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,19 +49,16 @@ function Footer() {
 export default function Home() {
   return (
     <div className="bg-background min-h-screen">
-      {/* Fixed navigation */}
       <TopNav />
       <SideNav />
-
-      {/* Main content — offset for side nav (desktop) and top nav */}
-      <main className="lg:pl-64 pt-20">
+      <main className="relative z-10 lg:pl-64 pt-20">
         <HeroSection />
-        <ArsenalSection />
-        <QuestSection />
-        <ExperienceSection />
-        <AccountLinksSection />
-        <ConnectSection />
-        <Footer />
+        <div data-reveal><ArsenalSection /></div>
+        <div data-reveal data-delay="1"><QuestSection /></div>
+        <div data-reveal><ExperienceSection /></div>
+        <div data-reveal data-delay="1"><AccountLinksSection /></div>
+        <div data-reveal><ConnectSection /></div>
+        <div data-reveal data-delay="2"><Footer /></div>
       </main>
     </div>
   );


### PR DESCRIPTION
Pure CSS + Intersection Observer — no extra dependencies.

- BackgroundOrbs: 4 slow-drifting blurred gradient circles (idle, always running)
- Scanline overlay on hero section (subtle idle texture)
- Hero badge breathe pulse + staggered entry (badge → name → bio → buttons, 150ms apart)
- [data-reveal] scroll reveals on all sections and Arsenal cards (fade up, threshold 12%)
- Skill bars animate from 0 to actual level on scroll (1.4s cubic-bezier)
- Arsenal cards stagger by column index (delay 1-3)
- prefers-reduced-motion: disables all animations