### PR TITLE
Fix nav scroll-spy bug, add changelog + version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A minimalist, neo-brutalist portfolio built as a CMS-driven website. Firebase Fi
 - Dynamic content from Firestore — no hardcoded portfolio data
 - `/profile` CMS dashboard — edit every section, upload profile photo, reorder items
 - Sections: Hero, Skills, Projects, Experience, Certificates, Links, Contact
+- Sidebar Changelog button — modal listing the version history (`lib/changelog.ts`)
+- Current version badge next to the nav brand, read straight from `package.json`
 - Scroll-reveal animations
 - Responsive — desktop sidebar nav, mobile top + bottom nav
 - `prefers-reduced-motion` support
@@ -80,6 +82,7 @@ Tagged with [Semantic Versioning](https://semver.org). `main` is auto-released b
 | `v2.0.0` | Next.js side-scrolling pixel-art game portfolio |
 | `v3.0.0` | Nexus dark glassmorphism CMS portfolio |
 | `v4.0.0` | Neo-brutalist "on paper" redesign |
+| `v4.1.0` | Certificates section, de-gamified UI, jdhomecillo rebrand |
 
 > Tags off `main` (e.g. milestones on `develop`) intentionally skip the `v*` prefix (e.g. `dev-v4.1.0`) — the release action picks the globally-highest `v*` tag with no branch-ancestry check, so a `v*`-prefixed tag anywhere in the repo can corrupt `main`'s computed version.
 

--- a/app/components/portfolio/ChangelogModal.tsx
+++ b/app/components/portfolio/ChangelogModal.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { CHANGELOG } from "@/lib/changelog";
+
+export function ChangelogModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // `open` only ever flips true from a client-side click, so document is
+  // always available by the time we reach this branch (SSR always sees
+  // open=false and bails above). Portal to <body>: rendering in place would
+  // nest this "fixed" overlay inside SideNav's <aside>, whose slide-in
+  // animation leaves a non-"none" transform at rest — that turns the aside
+  // into a containing block for fixed descendants, clipping the modal to
+  // the sidebar's width.
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-5 bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Changelog"
+      onClick={onClose}
+    >
+      <div
+        className="brutal-panel w-full max-w-lg max-h-[80vh] overflow-y-auto bg-surface"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-5 border-b-2 border-black sticky top-0 bg-surface">
+          <h2 className="font-display text-xl font-bold text-on-surface">Changelog</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close changelog"
+            className="brutal-press p-1 border-2 border-black bg-surface"
+          >
+            <span className="material-symbols-outlined text-[18px]">close</span>
+          </button>
+        </div>
+
+        <div className="p-5 space-y-6">
+          {CHANGELOG.map((entry) => (
+            <div key={entry.version}>
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[11px] font-mono px-1.5 py-0.5 border border-black bg-tertiary text-on-tertiary">
+                  {entry.version}
+                </span>
+                <h3 className="font-display text-sm font-semibold text-on-surface">
+                  {entry.title}
+                </h3>
+              </div>
+              <ul className="list-disc list-inside space-y-0.5">
+                {entry.notes.map((note, i) => (
+                  <li key={i} className="text-[13px] text-on-surface-variant leading-relaxed">
+                    {note}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/portfolio/ContactSection.tsx
+++ b/app/components/portfolio/ContactSection.tsx
@@ -6,7 +6,7 @@ import { usePortfolio } from "@/lib/contexts/PortfolioContext";
 const fieldCls =
   "w-full bg-surface-container border-2 border-black p-3 text-on-surface font-body text-sm outline-none placeholder:text-on-surface-variant/50 transition-shadow";
 
-export function ConnectSection() {
+export function ContactSection() {
   const { personalInfo } = usePortfolio();
   const [status, setStatus] = useState<"idle" | "sent">("idle");
 
@@ -25,7 +25,7 @@ export function ConnectSection() {
   };
 
   return (
-    <section id="connect" className="py-16 px-5 md:px-margin-desktop">
+    <section id="contact" className="py-16 px-5 md:px-margin-desktop">
       <div className="max-w-2xl mx-auto brutal-panel p-6 md:p-8">
         <div className="mb-8">
           <h2 className="font-display text-2xl md:text-3xl font-bold text-on-surface mb-1.5">

--- a/app/components/portfolio/HeroSection.tsx
+++ b/app/components/portfolio/HeroSection.tsx
@@ -32,7 +32,7 @@ export function HeroSection() {
               View Projects
             </a>
             <a
-              href="#connect"
+              href="#contact"
               className="brutal-press bg-surface border-2 border-black text-on-surface text-[13px] font-bold py-2.5 px-6 shadow-brutal-sm transition-all"
             >
               Contact

--- a/app/components/portfolio/SideNav.tsx
+++ b/app/components/portfolio/SideNav.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useState } from "react";
+import { ChangelogModal } from "./ChangelogModal";
+
 const NAV_LINKS = [
   { id: "home", label: "Home", icon: "home" },
   { id: "skills", label: "Skills", icon: "auto_awesome" },
@@ -10,6 +13,8 @@ const NAV_LINKS = [
 ];
 
 export function SideNav() {
+  const [changelogOpen, setChangelogOpen] = useState(false);
+
   return (
     <aside className="sidebar-entrance hidden lg:flex fixed left-0 top-0 h-full w-56 z-40 bg-surface border-r-4 border-black flex-col pt-24 pb-8">
       {/* Nav links */}
@@ -30,15 +35,24 @@ export function SideNav() {
         ))}
       </nav>
 
-      {/* CTA */}
-      <div className="px-6 mt-auto">
+      {/* Changelog + CTA */}
+      <div className="px-6 mt-auto space-y-2">
+        <button
+          onClick={() => setChangelogOpen(true)}
+          className="brutal-press w-full bg-surface text-on-surface py-2.5 px-4 text-[13px] font-bold border-2 border-black shadow-brutal-sm transition-all flex items-center justify-center gap-2"
+        >
+          <span className="material-symbols-outlined text-[16px]">history</span>
+          Changelog
+        </button>
         <a
-          href="#connect"
+          href="#contact"
           className="brutal-press w-full bg-primary text-on-primary py-2.5 px-4 text-[13px] font-bold border-2 border-black shadow-brutal-sm transition-all flex items-center justify-center gap-2"
         >
           Contact
         </a>
       </div>
+
+      <ChangelogModal open={changelogOpen} onClose={() => setChangelogOpen(false)} />
     </aside>
   );
 }

--- a/app/components/portfolio/TopNav.tsx
+++ b/app/components/portfolio/TopNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import packageJson from "@/package.json";
 
 const NAV_LINKS = [
   { id: "home", label: "Home" },
@@ -11,18 +12,24 @@ const NAV_LINKS = [
   { id: "links", label: "Links" },
 ];
 
+// Contact isn't a nav link (it's the standalone CTA button below), but it
+// still needs to be tracked here — otherwise scroll-spy has nothing to match
+// once you scroll past the last real nav link, and "Links" stays stuck
+// highlighted for the rest of the page (including Contact + the footer).
+const SCROLL_SECTION_IDS = [...NAV_LINKS.map((l) => l.id), "contact"];
+
 export function TopNav() {
   const [active, setActive] = useState("home");
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = NAV_LINKS.map((l) => document.getElementById(l.id));
+      const sections = SCROLL_SECTION_IDS.map((id) => document.getElementById(id));
       const scrollY = window.scrollY + 120;
       for (let i = sections.length - 1; i >= 0; i--) {
         const section = sections[i];
         if (section && section.offsetTop <= scrollY) {
-          setActive(NAV_LINKS[i].id);
+          setActive(SCROLL_SECTION_IDS[i]);
           break;
         }
       }
@@ -35,8 +42,13 @@ export function TopNav() {
     <header className="nav-entrance fixed top-0 w-full z-50 bg-surface border-b-4 border-black">
       <nav className="flex justify-between items-center h-16 px-5 md:px-margin-desktop w-full max-w-container-max mx-auto">
         {/* Brand */}
-        <div className="font-display text-lg font-bold text-on-surface select-none">
-          JDHomecillo
+        <div className="flex items-center gap-2 select-none">
+          <span className="font-display text-lg font-bold text-on-surface">
+            JDHomecillo
+          </span>
+          <span className="text-[10px] font-mono px-1.5 py-0.5 border border-black bg-tertiary text-on-tertiary">
+            v{packageJson.version}
+          </span>
         </div>
 
         {/* Desktop links */}
@@ -59,7 +71,7 @@ export function TopNav() {
 
         {/* Desktop CTA */}
         <a
-          href="#connect"
+          href="#contact"
           className="brutal-press hidden md:inline-flex bg-primary text-on-primary text-[13px] font-bold py-1.5 px-4 border-2 border-black shadow-brutal-sm transition-all"
         >
           Contact
@@ -93,7 +105,7 @@ export function TopNav() {
             </a>
           ))}
           <a
-            href="#connect"
+            href="#contact"
             onClick={() => setMenuOpen(false)}
             className="brutal-press block bg-primary text-on-primary text-[13px] font-bold py-2.5 px-4 border-2 border-black shadow-brutal-sm text-center transition-all mt-2"
           >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { SkillsSection } from "./components/portfolio/SkillsSection";
 import { ProjectsSection } from "./components/portfolio/ProjectsSection";
 import { ExperienceSection } from "./components/portfolio/ExperienceSection";
 import { CertificatesSection } from "./components/portfolio/CertificatesSection";
-import { ConnectSection } from "./components/portfolio/ConnectSection";
+import { ContactSection } from "./components/portfolio/ContactSection";
 import { LinksSection } from "./components/portfolio/LinksSection";
 import { Footer } from "./components/portfolio/Footer";
 
@@ -21,7 +21,7 @@ export default function Home() {
         <div data-reveal><ExperienceSection /></div>
         <div data-reveal data-delay="1"><CertificatesSection /></div>
         <div data-reveal><LinksSection /></div>
-        <div data-reveal data-delay="1"><ConnectSection /></div>
+        <div data-reveal data-delay="1"><ContactSection /></div>
         <div data-reveal data-delay="2"><Footer /></div>
       </main>
     </div>

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -1,0 +1,51 @@
+export type ChangelogEntry = {
+  version: string;
+  title: string;
+  notes: string[];
+};
+
+// Keep in sync with the version table in README.md.
+export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "v4.1.0",
+    title: "Certificates + de-gamified UI",
+    notes: [
+      "Added Certificates section and CMS tab",
+      "Removed skill proficiency bars/levels",
+      "Stripped remaining gamified/terminal styling and NEXUS branding",
+    ],
+  },
+  {
+    version: "v4.0.0",
+    title: "Neo-brutalist \"on paper\" redesign",
+    notes: [
+      "Flat, high-contrast visual overhaul: paper background, hard offset shadows, squared corners",
+      "Removed the old pixel-art game engine entirely",
+    ],
+  },
+  {
+    version: "v3.0.0",
+    title: "Nexus dark CMS portfolio",
+    notes: [
+      "Dark glassmorphism redesign",
+      "Firebase Auth + Firestore-backed CMS at /profile",
+      "Cloudinary image uploads, dynamic favicon",
+    ],
+  },
+  {
+    version: "v2.0.0",
+    title: "Pixel-art game portfolio",
+    notes: [
+      "Full rewrite on Next.js + TypeScript + HTML5 Canvas",
+      "Side-scrolling game shell with sprite character, monsters, scoring",
+    ],
+  },
+  {
+    version: "v1.0.0",
+    title: "Classic era",
+    notes: [
+      "Plain HTML/Bootstrap site with a Firestore-backed blog",
+      "ParaNawen Flutter companion app attempt",
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- **Bug fix**: top nav scroll-spy highlighted "Links" in teal permanently once scrolled past it (through Contact + footer), since Contact wasn't tracked in the scroll-spy's section list
- Add a version badge next to the nav brand (`v{package.json version}`), stays in sync automatically via the release automation
- Add a sidebar Changelog button that opens a modal listing version history (`lib/changelog.ts`)
- Rename Connect → Contact (`ConnectSection` → `ContactSection`, `id="connect"` → `id="contact"`) to match the rest of the de-gamified section names
- Docs updated to match

## Notes
- The changelog modal is rendered via a React portal to `document.body` — rendering in place clipped it to the sidebar's width, because `SideNav`'s slide-in animation leaves a non-`none` CSS transform on the `<aside>` at rest, which makes it a containing block for `fixed`-positioned descendants
- Verified: `npm run lint` and `npm run build` clean; scroll-spy fix and modal portal fix both confirmed visually via headless Chrome (computed nav-link colors at top/bottom of page, modal screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)